### PR TITLE
Fix opinit challenger l1 start height

### DIFF
--- a/models/opinit_bots/init.go
+++ b/models/opinit_bots/init.go
@@ -895,6 +895,7 @@ func WaitStartingInitBot(ctx context.Context) tea.Cmd {
 					RPCAddress:   configMap["l2_node.rpc_address"],
 					Bech32Prefix: "init",
 				},
+				L1StartHeight: 1,
 				L2StartHeight: 1,
 			}
 			configBz, err := json.MarshalIndent(config, "", " ")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new configuration field `L1StartHeight` for the Challenger bot, enhancing initialization clarity.
- **Improvements**
	- Streamlined bot initialization process for better robustness and error handling.
	- Enhanced user interface with tooltips for configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->