### PR TITLE
fix: remove macos interation tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,5 +41,3 @@ jobs:
 
       - name: Run Integration Tests
         run: cd tests && go test -v ./...
-
-  


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the order and dependencies of integration tests jobs in the workflow configuration for improved execution on macOS and Ubuntu.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->