### PR TITLE
Bump transaction timeout

### DIFF
--- a/cosmosutils/cli_tx.go
+++ b/cosmosutils/cli_tx.go
@@ -98,7 +98,7 @@ func (te *InitiadTxExecutor) BroadcastMsgSend(senderMnemonic, recipientAddress, 
 func (te *InitiadTxExecutor) waitForTransactionInclusion(rpcURL, txHash string) error {
 	// Poll for transaction status until it's included in a block
 	timeout := time.After(15 * time.Second)   // Example timeout for polling
-	ticker := time.NewTicker(3 * time.Second) // Poll every second
+	ticker := time.NewTicker(3 * time.Second) // Poll every 3 seconds
 	defer ticker.Stop()                       // Ensure cleanup of ticker resource
 
 	for {

--- a/models/minitia/tx.go
+++ b/models/minitia/tx.go
@@ -175,9 +175,9 @@ func (lsk *L1SystemKeys) FundAccountsWithGasStation(state *LaunchState) (*FundAc
 // waitForTransactionInclusion polls for the transaction inclusion in a block
 func (lsk *L1SystemKeys) waitForTransactionInclusion(binaryPath, rpcURL, txHash string) error {
 	// Poll for transaction status until it's included in a block
-	timeout := time.After(5 * time.Second) // Example timeout for polling
-	ticker := time.NewTicker(time.Second)  // Poll every second
-	defer ticker.Stop()                    // Ensure cleanup of ticker resource
+	timeout := time.After(15 * time.Second)   // Example timeout for polling
+	ticker := time.NewTicker(3 * time.Second) // Poll every 3 seconds
+	defer ticker.Stop()                       // Ensure cleanup of ticker resource
 
 	for {
 		select {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
	- Increased timeout duration for transaction inclusion polling from 5 seconds to 15 seconds.
	- Adjusted polling interval from 1 second to 3 seconds, resulting in fewer status checks.
	- Enhanced error handling and control flow for transaction processing, particularly for the Celestia network.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->