### PR TITLE
fix(start): add 1 sec delay before logging

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -6,6 +6,7 @@ import (
 	"os/signal"
 	"runtime"
 	"syscall"
+	"time"
 )
 
 type Service interface {
@@ -38,6 +39,7 @@ func NonDetachStart(s Service) error {
 			_ = s.Stop()
 			panic(err)
 		}
+		time.Sleep(1 * time.Second)
 		err = s.Log(100)
 		if err != nil {
 			_ = s.Stop()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Introduced a delay in service start-up to improve timing of operations and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->