### PR TITLE
Fix bug when recovering same l2 key as l1 input

### DIFF
--- a/models/relayer/init.go
+++ b/models/relayer/init.go
@@ -744,16 +744,16 @@ func (m *ImportL1RelayerKeyInput) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			model := NewFetchingBalancesLoading(weavecontext.SetCurrentState(m.Ctx, state))
 			return model, model.Init()
 		case L2SameKey:
-			state.l2RelayerAddress = relayerKey.Address
-			state.l2RelayerMnemonic = relayerKey.Mnemonic
 			l2ChainId, err := GetL2ChainId(m.Ctx)
 			if err != nil {
 				return m, m.HandlePanic(err)
 			}
-			relayerKey, err = cosmosutils.RecoverAndReplaceHermesKey(state.hermesBinaryPath, l2ChainId, state.l2RelayerMnemonic)
+			relayerKey, err = cosmosutils.RecoverAndReplaceHermesKey(state.hermesBinaryPath, l2ChainId, input.Text)
 			if err != nil {
 				return m, m.HandlePanic(err)
 			}
+			state.l2RelayerAddress = relayerKey.Address
+			state.l2RelayerMnemonic = relayerKey.Mnemonic
 			model := NewFetchingBalancesLoading(weavecontext.SetCurrentState(m.Ctx, state))
 			return model, model.Init()
 		case L2GenerateKey:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced key import functionality for relayers, allowing users to use the same key for both L1 and L2 networks.
	- Improved user experience for setting up relayer keys across different blockchain layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->