### PR TITLE
Only ctrl+c exits the loading state

### DIFF
--- a/ui/loading.go
+++ b/ui/loading.go
@@ -91,7 +91,7 @@ func (m Loading) Update(msg tea.Msg) (Loading, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		case "ctrl+c":
 			analytics.TrackEvent(analytics.Interrupted, analytics.NewEmptyEvent())
 			m.quitting = true
 			return m, tea.Quit


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Restricted loading process interruption to only "ctrl+c" key
	- Simplified quit control flow for loading screen

<!-- end of auto-generated comment: release notes by coderabbit.ai -->