### PR TITLE
Set correct rollup home when init relayer from weave init

### DIFF
--- a/models/weaveinit/weaveinit.go
+++ b/models/weaveinit/weaveinit.go
@@ -149,6 +149,7 @@ func (m *WeaveInit) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return model, model.Init()
 		case RunRelayerOption:
 			ctx := weavecontext.NewAppContext(relayer.NewRelayerState())
+			ctx = weavecontext.SetMinitiaHome(ctx, filepath.Join(homeDir, common.MinitiaDirectory))
 			ctx = weavecontext.SetWindowWidth(ctx, windowWidth)
 
 			analytics.AppendGlobalEventProperties(map[string]interface{}{


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved configuration handling for relayer option by correctly setting Minitia home directory context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->