### PR TITLE
Fix port clash between OPinit bots

### DIFF
--- a/models/opinit_bots/init.go
+++ b/models/opinit_bots/init.go
@@ -55,7 +55,7 @@ var defaultExecutorFields = []*Field{
 
 var defaultChallengerFields = []*Field{
 	// Listen Address
-	{Name: "listen_address", Type: StringField, Question: "Specify listen address of the bot", Highlights: []string{"listen address"}, Placeholder: `Press tab to use "localhost:3000"`, DefaultValue: "localhost:3000", ValidateFn: common.ValidateEmptyString, Tooltip: &tooltip.ListenAddressTooltip},
+	{Name: "listen_address", Type: StringField, Question: "Specify listen address of the bot", Highlights: []string{"listen address"}, Placeholder: `Press tab to use "localhost:3001"`, DefaultValue: "localhost:3001", ValidateFn: common.ValidateEmptyString, Tooltip: &tooltip.ListenAddressTooltip},
 
 	// L1 Node Configuration
 	{Name: "l1_node.rpc_address", Type: StringField, Question: "Specify L1 RPC endpoint", Highlights: []string{"L1 RPC endpoint"}, Placeholder: "Add RPC address ex. http://localhost:26657", ValidateFn: common.ValidateURL, Tooltip: &tooltip.L1RPCEndpointTooltip},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration Update**
	- Updated default listen address for Challenger bot from `localhost:3000` to `localhost:3001`

<!-- end of auto-generated comment: release notes by coderabbit.ai -->