### PR TITLE
Disable prerelease when releasing via actions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -75,7 +75,6 @@ jobs:
         with:
           name: ${{ github.ref_name }}
           draft: false
-          prerelease: true
           token: ${{ secrets.GH_RELEASE_TOKEN }}
           files: |
             weave_${{ github.ref_name }}_${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Configuration**
	- Modified GitHub Actions workflow to upload releases as stable releases instead of pre-releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->