### PR TITLE
Update url to weave binaries

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -15,8 +15,8 @@ import (
 )
 
 const (
-	WeaveReleaseAPI string = "https://api.github.com/repos/initia-labs/weave-binaries/releases"
-	WeaveReleaseURL string = "https://www.github.com/initia-labs/weave-binaries/releases"
+	WeaveReleaseAPI string = "https://api.github.com/repos/initia-labs/weave/releases"
+	WeaveReleaseURL string = "https://www.github.com/initia-labs/weave/releases"
 )
 
 func VersionCommand() *cobra.Command {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub repository references for Weave release API and URL from "weave-binaries" to "weave" repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->