### PR TITLE
README add easy installation for macOS and linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,15 +37,15 @@ Install _Weave_ by downloading the appropriate binary for your architecture usin
 **For x86_86 (amd64)**
 
 ```bash
-wget https://github.com/initia-labs/weave/releases/download/v0.1.1/weave-0.1.1-linux-amd64.tar.gz
-tar -xvf weave-0.1.1-linux-amd64.tar.gz
+wget https://github.com/initia-labs/weave/releases/download/v0.1.2/weave-0.1.2-linux-amd64.tar.gz
+tar -xvf weave-0.1.2-linux-amd64.tar.gz
 ```
 
 **For arm64**
 
 ```bash
-wget https://github.com/initia-labs/weave/releases/download/v0.1.1/weave-0.1.1-linux-arm64.tar.gz
-tar -xvf weave-0.1.1-linux-arm64.tar.gz
+wget https://github.com/initia-labs/weave/releases/download/v0.1.2/weave-0.1.2-linux-arm64.tar.gz
+tar -xvf weave-0.1.2-linux-arm64.tar.gz
 ```
 
 ### Building from Scratch
@@ -55,7 +55,7 @@ To build _Weave_ from source, you will need a working Go environment and `make`.
 ```bash
 git clone https://github.com/initia-labs/weave.git
 cd weave
-git checkout tags/v0.1.1
+git checkout tags/v0.1.2
 make install
 ```
 
@@ -71,7 +71,7 @@ weave version
 This should return the version of the Weave binary you have installed. Example output:
 
 ```bash
-v0.1.1
+v0.1.2
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,35 @@ Its primary purpose is to solve several key challenges:
 
 ## Installation
 
+### On macOS
+
+Install _Weave_ via [Homebrew](https://brew.sh/):
+
+```bash
+brew install initia-labs/tap/weave
+```
+
+### On Linux
+
+Install _Weave_ by downloading the appropriate binary for your architecture using `wget`:
+
+**For x86_86 (amd64)**
+
+```bash
+wget https://github.com/initia-labs/weave/releases/download/v0.1.1/weave-0.1.1-linux-amd64.tar.gz
+tar -xvf weave-0.1.1-linux-amd64.tar.gz
+```
+
+**For arm64**
+
+```bash
+wget https://github.com/initia-labs/weave/releases/download/v0.1.1/weave-0.1.1-linux-arm64.tar.gz
+tar -xvf weave-0.1.1-linux-arm64.tar.gz
+```
+
 ### Building from Scratch
+
+To build _Weave_ from source, you will need a working Go environment and `make`. Follow these steps:
 
 ```bash
 git clone https://github.com/initia-labs/weave.git


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated README with detailed installation instructions for Weave CLI
	- Added Homebrew installation method for macOS
	- Included binary installation steps for Linux (x86_64 and arm64)
	- Clarified prerequisites for building Weave from source
	- Updated version number in "Verify Installation" section from v0.1.1 to v0.1.2
<!-- end of auto-generated comment: release notes by coderabbit.ai -->