### PR TITLE
Fix relayer integration tests to be done on Minievm only

### DIFF
--- a/cmd/relayer_integration_test.go
+++ b/cmd/relayer_integration_test.go
@@ -4,7 +4,6 @@
 package cmd_test
 
 import (
-	"github.com/initia-labs/weave/registry"
 	"os"
 	"path/filepath"
 	"sort"
@@ -15,6 +14,7 @@ import (
 
 	weavecontext "github.com/initia-labs/weave/context"
 	"github.com/initia-labs/weave/models/relayer"
+	"github.com/initia-labs/weave/registry"
 	"github.com/initia-labs/weave/testutil"
 )
 

--- a/cmd/relayer_integration_test.go
+++ b/cmd/relayer_integration_test.go
@@ -4,8 +4,11 @@
 package cmd_test
 
 import (
+	"github.com/initia-labs/weave/registry"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -22,15 +25,41 @@ func TestRelayerInit(t *testing.T) {
 	firstModel, err := relayer.NewRollupSelect(ctx)
 	assert.Nil(t, err)
 
-	steps := []testutil.Step{
+	miniEvmIdx := -1
+	networks, err := registry.GetAllL2AvailableNetwork(registry.InitiaL1Testnet)
+	if err != nil {
+		t.Fatalf("get all l2 available networks: %v", err)
+	}
+
+	sort.Slice(networks, func(i, j int) bool {
+		return strings.ToLower(networks[i].PrettyName) < strings.ToLower(networks[j].PrettyName)
+	})
+	for i, network := range networks {
+		if strings.EqualFold(network.PrettyName, "Minievm") {
+			miniEvmIdx = i
+			break
+		}
+	}
+
+	if miniEvmIdx == -1 {
+		t.Fatalf("'Minievm' not found in networks")
+	}
+
+	pressDownSteps := make(testutil.Steps, miniEvmIdx)
+	for i := 0; i < miniEvmIdx; i++ {
+		pressDownSteps[i] = testutil.PressDown
+	}
+
+	steps := testutil.Steps{
 		testutil.PressEnter,   // press enter to confirm selecting whitelisted rollups
 		testutil.PressEnter,   // press enter to confirm selecting testnet
 		testutil.WaitFetching, // wait fetching rollup networks
-		testutil.PressDown,    // press down once to move the selector
-		testutil.PressDown,    // press down again to move the selector to minievm
-		testutil.PressEnter,   // press enter to confirm selecting minievm
-		testutil.PressSpace,   // press space to select relaying all channels
-		testutil.PressEnter,   // press enter to confirm the selection
+	}
+	steps = append(steps, pressDownSteps...) // press down until its minievm
+	steps = append(steps, testutil.Steps{
+		testutil.PressEnter, // press enter to confirm selecting minievm
+		testutil.PressSpace, // press space to select relaying all channels
+		testutil.PressEnter, // press enter to confirm the selection
 		testutil.WaitFor(func() bool {
 			userHome, _ := os.UserHomeDir()
 			if _, err := os.Stat(filepath.Join(userHome, relayer.HermesHome, "config.toml")); os.IsNotExist(err) {
@@ -48,7 +77,7 @@ func TestRelayerInit(t *testing.T) {
 		testutil.PressDown,            // press down once to move the selector
 		testutil.PressDown,            // press down again to move the selector to skip the funding
 		testutil.PressEnter,           // press enter to confirm the selection
-	}
+	}...)
 
 	finalModel := testutil.RunProgramWithSteps(t, firstModel, steps)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Enhanced integration test for relayer initialization
	- Added dynamic network selection logic for "Minievm" network
	- Improved test robustness by adapting to available networks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->